### PR TITLE
feat: tool search for MCP tool definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ Evaluation configs support both YAML and JSON formats:
 - `timeout` - Per-evaluation timeout (e.g., "2m", "30s")
 - `max_steps` - Maximum agentic loop iterations (default: 10)
 - `max_tokens` - Maximum tokens per LLM request (default: 4096)
+- `enable_prompt_caching` - Cache tool definitions and system prompts (default: true)
+- `cache_ttl` - Cache time-to-live: "5m" (default, free) or "1h" (premium)
+- `enable_tool_search` - Defer MCP tool schemas and add a BM25 tool-search tool so the model loads only the tools relevant to each prompt (default: true). Set to false to send all tool definitions eagerly.
+- `enforce_minimum_scores` - Fail evals that miss rubric minimum scores (default: true)
 - `mcp_server` - Server command, args, and environment
 - `evals` - List of test cases with name, prompt, and expected result
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -40,5 +40,10 @@ func createClient(config *evaluations.EvalConfig, apiKey, baseURL string, quiet 
 		clientConfig.CacheTTL = config.CacheTTL
 	}
 
+	// Map tool search configuration from YAML to client config
+	if config.EnableToolSearch != nil {
+		clientConfig.EnableToolSearch = config.EnableToolSearch
+	}
+
 	return evaluations.NewEvalClient(clientConfig)
 }

--- a/internal/reporting/report.go
+++ b/internal/reporting/report.go
@@ -156,6 +156,7 @@ func captureOverallStats(results []evaluations.EvalRunResult, styles help.Styles
 	totalOutputTokens := 0
 	totalToolCalls := 0
 	successfulToolCalls := 0
+	totalToolSearches := 0
 	totalCacheCreationTokens := 0
 	totalCacheReadTokens := 0
 
@@ -170,6 +171,7 @@ func captureOverallStats(results []evaluations.EvalRunResult, styles help.Styles
 			totalInputTokens += result.Trace.TotalInputTokens
 			totalOutputTokens += result.Trace.TotalOutputTokens
 			totalToolCalls += result.Trace.ToolCallCount
+			totalToolSearches += result.Trace.ToolSearchCount
 			totalCacheCreationTokens += result.Trace.TotalCacheCreationTokens
 			totalCacheReadTokens += result.Trace.TotalCacheReadTokens
 
@@ -242,23 +244,29 @@ func captureOverallStats(results []evaluations.EvalRunResult, styles help.Styles
 	}
 
 	// Tool execution stats
-	if totalToolCalls > 0 {
+	if totalToolCalls > 0 || totalToolSearches > 0 {
 		output.WriteString(h3(styles, "Tool Execution"))
 		fmt.Fprintf(&output, "Total Tool Calls:   %d\n", totalToolCalls)
 
-		successRateOverall := float64(successfulToolCalls) / float64(totalToolCalls) * 100
-		successRateStr := fmt.Sprintf("%.0f%% (%d/%d)", successRateOverall, successfulToolCalls, totalToolCalls)
-		if successRateOverall >= 80 {
-			successRateStr = styles.Success.Render(successRateStr)
-		} else if successRateOverall < 50 {
-			successRateStr = styles.Error.Render(successRateStr)
+		if totalToolSearches > 0 {
+			fmt.Fprintf(&output, "Tool Searches:      %d\n", totalToolSearches)
 		}
-		fmt.Fprintf(&output, "Success Rate:       %s\n", successRateStr)
 
-		if totalToolCalls > successfulToolCalls {
-			failedCalls := totalToolCalls - successfulToolCalls
-			fmt.Fprintf(&output, "Failed Calls:       %s\n",
-				styles.Error.Render(fmt.Sprintf("%d", failedCalls)))
+		if totalToolCalls > 0 {
+			successRateOverall := float64(successfulToolCalls) / float64(totalToolCalls) * 100
+			successRateStr := fmt.Sprintf("%.0f%% (%d/%d)", successRateOverall, successfulToolCalls, totalToolCalls)
+			if successRateOverall >= 80 {
+				successRateStr = styles.Success.Render(successRateStr)
+			} else if successRateOverall < 50 {
+				successRateStr = styles.Error.Render(successRateStr)
+			}
+			fmt.Fprintf(&output, "Success Rate:       %s\n", successRateStr)
+
+			if totalToolCalls > successfulToolCalls {
+				failedCalls := totalToolCalls - successfulToolCalls
+				fmt.Fprintf(&output, "Failed Calls:       %s\n",
+					styles.Error.Render(fmt.Sprintf("%d", failedCalls)))
+			}
 		}
 		output.WriteString("\n")
 	}
@@ -390,6 +398,24 @@ func captureEvalDetail(result evaluations.EvalRunResult, styles help.Styles) str
 					if tool.Error != "" {
 						fmt.Fprintf(&output, "    Error: %s\n", tool.Error)
 					}
+				}
+			}
+
+			// Show server-side tool searches
+			for _, search := range step.ToolSearches {
+				fmt.Fprintf(&output, "  Tool Search: %s\n", search.ToolName)
+				if len(search.Query) > 0 {
+					fmt.Fprintf(&output, "    Query: %s\n", string(search.Query))
+				}
+				if search.Error != "" {
+					fmt.Fprintf(&output, "    %s %s\n",
+						styles.Error.Render("✗ Failed"),
+						search.Error)
+				} else {
+					fmt.Fprintf(&output, "    %s found %d tool(s): %s\n",
+						styles.Success.Render("✓"),
+						len(search.ToolsFound),
+						strings.Join(search.ToolsFound, ", "))
 				}
 			}
 

--- a/mcp_eval_config.go
+++ b/mcp_eval_config.go
@@ -34,6 +34,7 @@ type EvalConfig struct {
 	EnablePromptCaching  *bool           `yaml:"enable_prompt_caching,omitempty" json:"enable_prompt_caching,omitempty" jsonschema:"Enable Anthropic prompt caching for tool definitions and system prompts (defaults to true for cost savings)"`
 	CacheTTL             string          `yaml:"cache_ttl,omitempty" json:"cache_ttl,omitempty" jsonschema:"Cache time-to-live: '5m' (default, free) or '1h' (premium). Requires enable_prompt_caching=true"`
 	EnforceMinimumScores *bool           `yaml:"enforce_minimum_scores,omitempty" json:"enforce_minimum_scores,omitempty" jsonschema:"Enforce minimum scores from grading rubrics (defaults to true; set to false to disable)"`
+	EnableToolSearch     *bool           `yaml:"enable_tool_search,omitempty" json:"enable_tool_search,omitempty" jsonschema:"Enable tool search: defer MCP tool schemas and add a BM25 tool-search tool so Claude loads only relevant tools (defaults to true)"`
 	MCPServer            MCPServerConfig `yaml:"mcp_server" json:"mcp_server" jsonschema:"Configuration for the MCP server to evaluate"`
 	Evals                []Eval          `yaml:"evals" json:"evals" jsonschema:"List of evaluation test cases to run"`
 }

--- a/mcp_evals.go
+++ b/mcp_evals.go
@@ -55,6 +55,7 @@ type EvalClientConfig struct {
 	MaxTokens            int
 	EnablePromptCaching  *bool             // Optional: enable Anthropic prompt caching for tool definitions and system prompts. Default: true
 	CacheTTL             string            // Optional: cache time-to-live, either "5m" (default) or "1h". Requires EnablePromptCaching=true
+	EnableToolSearch     *bool             // Optional: enable tool search (defer MCP tool schemas and add a BM25 tool-search tool). Default: true
 	EnforceMinimumScores *bool             // Optional: enforce minimum scores from grading rubrics. Default: true
 	StderrCallback       func(line string) // Optional: called for each line written to stderr by the MCP server subprocess
 }
@@ -76,6 +77,9 @@ func (c *EvalClientConfig) ApplyDefaults() *EvalClientConfig {
 	}
 	if c.EnforceMinimumScores == nil {
 		c.EnforceMinimumScores = toPtr(true) // Enable minimum score enforcement by default
+	}
+	if c.EnableToolSearch == nil {
+		c.EnableToolSearch = toPtr(true) // Enable tool search by default to keep the initial prompt small
 	}
 	return c
 }
@@ -241,42 +245,7 @@ func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, e
 	trace.ServerInstructions = serverInstructions
 
 	// convert the tools to the format expected by the anthropic model
-	toolParams := make([]anthropic.ToolParam, 0, len(toolsResp.Tools))
-	for _, tool := range toolsResp.Tools {
-		// Convert the MCP tool input schema to Anthropic format
-		var properties map[string]any
-		if tool.InputSchema != nil {
-			// MCP uses JSON Schema, convert to map
-			schemaBytes, _ := json.Marshal(tool.InputSchema)
-			var schema map[string]any
-			if err := json.Unmarshal(schemaBytes, &schema); err == nil {
-				if props, ok := schema["properties"].(map[string]any); ok {
-					properties = props
-				}
-			}
-		}
-
-		toolParam := anthropic.ToolParam{
-			Name:        tool.Name,
-			Description: anthropic.String(tool.Description),
-			InputSchema: anthropic.ToolInputSchemaParam{
-				Properties: properties,
-			},
-		}
-		toolParams = append(toolParams, toolParam)
-	}
-
-	// Add cache control to the last tool definition if caching is enabled
-	// This creates a cache breakpoint after all tools, maximizing cache reuse
-	if ec.cachingEnabled() && len(toolParams) > 0 {
-		lastIdx := len(toolParams) - 1
-		toolParams[lastIdx].CacheControl = ec.newCacheControl()
-	}
-
-	tools := make([]anthropic.ToolUnionParam, len(toolParams))
-	for i, toolParam := range toolParams {
-		tools[i] = anthropic.ToolUnionParam{OfTool: &toolParam}
-	}
+	tools := ec.buildTools(toolsResp.Tools)
 
 	// Initialize message history
 	messages := []anthropic.MessageParam{
@@ -443,6 +412,75 @@ func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, e
 	trace.TotalDuration = time.Since(overallStart)
 
 	return result, nil
+}
+
+// buildTools converts MCP tools into the tool definitions sent to the model.
+//
+// When tool search is enabled, the MCP tool schemas are marked defer_loading so
+// they are not included in the initial prompt; a non-deferred BM25 tool-search
+// tool is appended so Claude can discover and load only the relevant schemas on
+// demand. When tool search is disabled, every MCP tool is sent eagerly, matching
+// the previous behaviour.
+func (ec *EvalClient) buildTools(mcpTools []*mcp.Tool) []anthropic.ToolUnionParam {
+	toolParams := make([]anthropic.ToolParam, 0, len(mcpTools))
+	for _, tool := range mcpTools {
+		// Convert the MCP tool input schema to Anthropic format
+		var properties map[string]any
+		if tool.InputSchema != nil {
+			// MCP uses JSON Schema, convert to map
+			schemaBytes, _ := json.Marshal(tool.InputSchema)
+			var schema map[string]any
+			if err := json.Unmarshal(schemaBytes, &schema); err == nil {
+				if props, ok := schema["properties"].(map[string]any); ok {
+					properties = props
+				}
+			}
+		}
+
+		toolParams = append(toolParams, anthropic.ToolParam{
+			Name:        tool.Name,
+			Description: anthropic.String(tool.Description),
+			InputSchema: anthropic.ToolInputSchemaParam{
+				Properties: properties,
+			},
+		})
+	}
+
+	// Defer the MCP tool schemas when tool search is enabled. At least one tool
+	// must remain non-deferred (the search tool, appended below), so this only
+	// applies when there are MCP tools to defer.
+	useToolSearch := ec.toolSearchEnabled() && len(toolParams) > 0
+	if useToolSearch {
+		for i := range toolParams {
+			toolParams[i].DeferLoading = anthropic.Bool(true)
+		}
+	}
+
+	tools := make([]anthropic.ToolUnionParam, 0, len(toolParams)+1)
+	for i := range toolParams {
+		tools = append(tools, anthropic.ToolUnionParam{OfTool: &toolParams[i]})
+	}
+
+	if useToolSearch {
+		tools = append(tools, anthropic.ToolUnionParamOfToolSearchToolBm25_20251119(
+			anthropic.ToolSearchToolBm25_20251119TypeToolSearchToolBm25_20251119,
+		))
+	}
+
+	// Place a single cache breakpoint after all tool definitions, on the last
+	// tool in the array (the search tool when tool search is on, otherwise the
+	// last MCP tool), maximizing cache reuse across steps.
+	if ec.cachingEnabled() && len(tools) > 0 {
+		last := &tools[len(tools)-1]
+		switch {
+		case last.OfTool != nil:
+			last.OfTool.CacheControl = ec.newCacheControl()
+		case last.OfToolSearchToolBm25_20251119 != nil:
+			last.OfToolSearchToolBm25_20251119.CacheControl = ec.newCacheControl()
+		}
+	}
+
+	return tools
 }
 
 func (ec *EvalClient) buildAgentSystemPrompt(eval Eval, serverInstructions string) []anthropic.TextBlockParam {
@@ -861,6 +899,11 @@ func toPtr[T any](v T) *T {
 // cachingEnabled returns true if prompt caching is enabled in the config.
 func (ec *EvalClient) cachingEnabled() bool {
 	return ec.config.EnablePromptCaching != nil && *ec.config.EnablePromptCaching
+}
+
+// toolSearchEnabled returns true if tool search is enabled in the config.
+func (ec *EvalClient) toolSearchEnabled() bool {
+	return ec.config.EnableToolSearch != nil && *ec.config.EnableToolSearch
 }
 
 // newCacheControl builds an ephemeral cache control param with the configured TTL.

--- a/mcp_evals.go
+++ b/mcp_evals.go
@@ -283,6 +283,31 @@ func extractToolSearches(message anthropic.Message) []ToolSearch {
 	return searches
 }
 
+// repairToolSearchBlocks restores tool_search_tool_result content blocks that
+// anthropic-sdk-go v1.52.0 corrupts during streaming accumulation.
+//
+// On each ContentBlockStopEvent the SDK re-marshals the accumulated block to
+// refresh its cached raw JSON, but that round-trip collapses the result block's
+// content union into an empty error variant ("type":"tool_search_tool_result_error"
+// with no error_code). Both trace extraction and message.ToParam() then read the
+// corrupted block, the latter producing a request the API rejects with
+// "tool_search_tool_result.content.RequestToolSearchToolResultError.error_code:
+// Field required". The block arrives intact in its content_block_start event, so
+// re-unmarshalling that captured payload by index reinstates the correct content.
+func repairToolSearchBlocks(message *anthropic.Message, raws map[int64]string) {
+	for idx, raw := range raws {
+		if idx < 0 || int(idx) >= len(message.Content) {
+			continue
+		}
+		if err := message.Content[idx].UnmarshalJSON([]byte(raw)); err != nil {
+			log.Warn().
+				Err(err).
+				Int64("index", idx).
+				Msg("Failed to restore tool_search_tool_result block; history round-trip may fail")
+		}
+	}
+}
+
 func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, error) {
 	overallStart := time.Now()
 	trace := &EvalTrace{
@@ -334,6 +359,12 @@ func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, e
 
 		message := anthropic.Message{}
 
+		// tool_search_tool_result blocks arrive fully-formed in their
+		// content_block_start event and are not delta-streamed. Capture that
+		// intact payload by index so it can be restored after accumulation (see
+		// repairToolSearchBlocks for the SDK bug this works around).
+		toolSearchRaws := map[int64]string{}
+
 		// Process the stream
 		for stream.Next() {
 			event := stream.Current()
@@ -343,8 +374,13 @@ func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, e
 				return nil, fmt.Errorf("failed to accumulate event: %w", err)
 			}
 
-			if evt, ok := event.AsAny().(anthropic.ContentBlockDeltaEvent); ok {
+			switch evt := event.AsAny().(type) {
+			case anthropic.ContentBlockDeltaEvent:
 				finalText.WriteString(evt.Delta.Text)
+			case anthropic.ContentBlockStartEvent:
+				if evt.ContentBlock.Type == "tool_search_tool_result" {
+					toolSearchRaws[evt.Index] = evt.ContentBlock.RawJSON()
+				}
 			}
 		}
 
@@ -353,6 +389,10 @@ func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, e
 			trace.Steps = append(trace.Steps, step)
 			return nil, fmt.Errorf("streaming error: %w", err)
 		}
+
+		// Restore tool-search result blocks mangled by streaming accumulation
+		// before they are read for tracing or echoed back into message history.
+		repairToolSearchBlocks(&message, toolSearchRaws)
 
 		// Record step data from message
 		step.StopReason = string(message.StopReason)

--- a/mcp_evals.go
+++ b/mcp_evals.go
@@ -382,6 +382,15 @@ func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, e
 			break
 		}
 
+		// pause_turn signals a long-running server-side tool (e.g. tool search)
+		// paused the turn. The assistant message is already in history, so
+		// continue the loop to let the model resume rather than terminating the
+		// eval early. The MaxSteps bound still guards against an unbounded loop.
+		if message.StopReason == anthropic.StopReasonPauseTurn {
+			finalizeStep(&step, trace)
+			continue
+		}
+
 		if message.StopReason != anthropic.StopReasonToolUse {
 			finalizeStep(&step, trace)
 			break

--- a/mcp_evals.go
+++ b/mcp_evals.go
@@ -349,6 +349,13 @@ func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, e
 
 		systemPrompt := ec.buildAgentSystemPrompt(eval, serverInstructions)
 
+		// Maintain a rolling cache breakpoint on the most recent message so the
+		// growing conversation transcript (large tool results in particular) is
+		// served from cache on later steps instead of being re-sent at full price.
+		if ec.cachingEnabled() {
+			applyRollingCacheBreakpoint(messages, ec.newCacheControl())
+		}
+
 		stream := ec.client.Messages.NewStreaming(ctx, anthropic.MessageNewParams{
 			Model:     anthropic.Model(ec.config.Model),
 			MaxTokens: int64(ec.config.MaxTokens),
@@ -1038,6 +1045,55 @@ func (ec *EvalClient) newCacheControl() anthropic.CacheControlEphemeralParam {
 		cc.TTL = "1h"
 	}
 	return cc
+}
+
+// applyRollingCacheBreakpoint maintains a single cache breakpoint on the most
+// recent message so the conversation transcript is read from cache on later
+// agentic steps instead of being re-sent at full price.
+//
+// Anthropic allows at most four cache breakpoints per request and the system
+// prompt and tool definitions already consume two, so the previous message
+// breakpoint is cleared before the new one is set. Clearing the marker does not
+// evict the cache entry it created; that entry persists server-side by TTL and
+// is still read automatically via longest-prefix matching on the next request.
+func applyRollingCacheBreakpoint(messages []anthropic.MessageParam, cc anthropic.CacheControlEphemeralParam) {
+	var clear anthropic.CacheControlEphemeralParam
+	for i := range messages {
+		content := messages[i].Content
+		for j := range content {
+			setBlockCacheControl(&content[j], clear)
+		}
+	}
+
+	if len(messages) == 0 {
+		return
+	}
+	last := &messages[len(messages)-1]
+	if len(last.Content) == 0 {
+		return
+	}
+	setBlockCacheControl(&last.Content[len(last.Content)-1], cc)
+}
+
+// setBlockCacheControl sets the cache control on whichever variant of the
+// content block union is populated. Passing the zero value clears it (the field
+// marshals as omitzero). Variants that do not support cache control, such as
+// thinking blocks, are left untouched.
+func setBlockCacheControl(block *anthropic.ContentBlockParamUnion, cc anthropic.CacheControlEphemeralParam) {
+	switch {
+	case block.OfText != nil:
+		block.OfText.CacheControl = cc
+	case block.OfToolResult != nil:
+		block.OfToolResult.CacheControl = cc
+	case block.OfToolUse != nil:
+		block.OfToolUse.CacheControl = cc
+	case block.OfImage != nil:
+		block.OfImage.CacheControl = cc
+	case block.OfDocument != nil:
+		block.OfDocument.CacheControl = cc
+	case block.OfServerToolUse != nil:
+		block.OfServerToolUse.CacheControl = cc
+	}
 }
 
 // finalizeStep records the end time, duration, and appends the step to the trace.

--- a/mcp_evals.go
+++ b/mcp_evals.go
@@ -226,6 +226,63 @@ func (ec *EvalClient) executeAndTraceToolCall(
 	return toolCall
 }
 
+// extractToolSearches pulls server-side tool-search activity out of an assistant
+// message. The model's search calls arrive as server_tool_use blocks and their
+// results as tool_search_tool_result blocks; both are paired by tool-use ID so
+// the trace records what was searched and which tool schemas were surfaced. This
+// is the only place tool-search activity is captured, because the search runs
+// server-side and never round-trips through executeAndTraceToolCall.
+func extractToolSearches(message anthropic.Message) []ToolSearch {
+	byID := make(map[string]*ToolSearch)
+	order := make([]string, 0)
+	get := func(id string) *ToolSearch {
+		ts, ok := byID[id]
+		if !ok {
+			ts = &ToolSearch{ToolUseID: id}
+			byID[id] = ts
+			order = append(order, id)
+		}
+		return ts
+	}
+
+	for _, block := range message.Content {
+		switch b := block.AsAny().(type) {
+		case anthropic.ServerToolUseBlock:
+			// Only the tool-search server tools are relevant here; other server
+			// tools (web search, code execution) are not used by this client.
+			if !strings.HasPrefix(string(b.Name), "tool_search_tool") {
+				continue
+			}
+			ts := get(b.ID)
+			ts.ToolName = string(b.Name)
+			if input, err := json.Marshal(b.Input); err == nil {
+				ts.Query = input
+			}
+		case anthropic.ToolSearchToolResultBlock:
+			ts := get(b.ToolUseID)
+			content := b.Content
+			if content.ErrorCode != "" {
+				ts.Error = string(content.ErrorCode)
+				if content.ErrorMessage != "" {
+					ts.Error = fmt.Sprintf("%s: %s", content.ErrorCode, content.ErrorMessage)
+				}
+			}
+			for _, ref := range content.ToolReferences {
+				ts.ToolsFound = append(ts.ToolsFound, ref.ToolName)
+			}
+		}
+	}
+
+	if len(order) == 0 {
+		return nil
+	}
+	searches := make([]ToolSearch, 0, len(order))
+	for _, id := range order {
+		searches = append(searches, *byID[id])
+	}
+	return searches
+}
+
 func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, error) {
 	overallStart := time.Now()
 	trace := &EvalTrace{
@@ -313,6 +370,9 @@ func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, e
 			}
 		}
 
+		// Capture any server-side tool searches the model performed this step.
+		step.ToolSearches = extractToolSearches(message)
+
 		// Add assistant message to history
 		messages = append(messages, message.ToParam())
 
@@ -368,6 +428,7 @@ func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, e
 		trace.TotalInputTokens += step.InputTokens
 		trace.TotalOutputTokens += step.OutputTokens
 		trace.ToolCallCount += len(step.ToolCalls)
+		trace.ToolSearchCount += len(step.ToolSearches)
 
 		// Aggregate cache metrics
 		trace.TotalCacheCreationTokens += step.CacheCreationInputTokens
@@ -840,6 +901,7 @@ type EvalTrace struct {
 	TotalOutputTokens        int           `json:"total_output_tokens"`           // Sum of output tokens across all steps
 	StepCount                int           `json:"step_count"`                    // Number of agentic steps executed
 	ToolCallCount            int           `json:"tool_call_count"`               // Total number of tool calls made
+	ToolSearchCount          int           `json:"tool_search_count"`             // Total number of server-side tool searches performed
 	TotalCacheCreationTokens int           `json:"total_cache_creation_tokens"`   // Sum of cache creation tokens across all steps
 	TotalCacheReadTokens     int           `json:"total_cache_read_tokens"`       // Sum of cache read tokens across all steps
 }
@@ -853,6 +915,7 @@ type AgenticStep struct {
 	ModelResponse            string        `json:"model_response"`              // Text content from assistant
 	StopReason               string        `json:"stop_reason"`                 // end_turn, tool_use, max_tokens, etc.
 	ToolCalls                []ToolCall    `json:"tool_calls"`                  // Tools executed in this step
+	ToolSearches             []ToolSearch  `json:"tool_searches,omitempty"`     // Server-side tool searches performed in this step
 	InputTokens              int           `json:"input_tokens"`                // Input tokens for this step
 	OutputTokens             int           `json:"output_tokens"`               // Output tokens for this step
 	CacheCreationInputTokens int           `json:"cache_creation_input_tokens"` // Tokens used to create cache
@@ -871,6 +934,19 @@ type ToolCall struct {
 	Output    json.RawMessage `json:"output"`          // Tool result as JSON
 	Success   bool            `json:"success"`         // Whether tool executed successfully
 	Error     string          `json:"error,omitempty"` // Error message if tool failed
+}
+
+// ToolSearch captures a single server-side tool-search invocation and the tool
+// schemas it surfaced. When tool search is enabled the model calls the BM25
+// search tool and Anthropic executes it inline, so these never pass through
+// executeAndTraceToolCall; they are extracted from the response content blocks
+// purely for observability.
+type ToolSearch struct {
+	ToolUseID  string          `json:"tool_use_id"`           // ID linking the server_tool_use call to its result block
+	ToolName   string          `json:"tool_name"`             // Search tool name, e.g. "tool_search_tool_bm25"
+	Query      json.RawMessage `json:"query,omitempty"`       // Search input (queries) as JSON
+	ToolsFound []string        `json:"tools_found,omitempty"` // Tool names surfaced by the search
+	Error      string          `json:"error,omitempty"`       // Error message if the search failed
 }
 
 // GradingTrace records the grading interaction with the LLM

--- a/mcp_evals_test.go
+++ b/mcp_evals_test.go
@@ -250,6 +250,91 @@ func TestEvalClient_buildTools(t *testing.T) {
 	}
 }
 
+func TestExtractToolSearches(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string // JSON array of content blocks for the assistant message
+		wantSearch  []ToolSearch
+		wantNilZero bool // expect no searches returned
+	}{
+		{
+			name: "successful search records query and tools found",
+			content: `[
+				{"type":"text","text":"Let me find a tool."},
+				{"type":"server_tool_use","id":"srvtoolu_1","name":"tool_search_tool_bm25","caller":{"type":"direct"},"input":{"queries":["add two numbers"]}},
+				{"type":"tool_search_tool_result","tool_use_id":"srvtoolu_1","content":{"type":"tool_search_tool_search_result","tool_references":[{"type":"tool_reference","tool_name":"add"},{"type":"tool_reference","tool_name":"sum"}]}}
+			]`,
+			wantSearch: []ToolSearch{{
+				ToolUseID:  "srvtoolu_1",
+				ToolName:   "tool_search_tool_bm25",
+				Query:      json.RawMessage(`{"queries":["add two numbers"]}`),
+				ToolsFound: []string{"add", "sum"},
+			}},
+		},
+		{
+			name: "failed search records error",
+			content: `[
+				{"type":"server_tool_use","id":"srvtoolu_2","name":"tool_search_tool_bm25","caller":{"type":"direct"},"input":{"queries":["x"]}},
+				{"type":"tool_search_tool_result","tool_use_id":"srvtoolu_2","content":{"type":"tool_search_tool_result_error","error_code":"unavailable","error_message":"search backend down"}}
+			]`,
+			wantSearch: []ToolSearch{{
+				ToolUseID: "srvtoolu_2",
+				ToolName:  "tool_search_tool_bm25",
+				Query:     json.RawMessage(`{"queries":["x"]}`),
+				Error:     "unavailable: search backend down",
+			}},
+		},
+		{
+			name: "message without tool search returns nothing",
+			content: `[
+				{"type":"text","text":"hello"},
+				{"type":"tool_use","id":"toolu_9","name":"add","input":{"a":1,"b":2}}
+			]`,
+			wantNilZero: true,
+		},
+		{
+			name: "multiple searches preserve order",
+			content: `[
+				{"type":"server_tool_use","id":"srvtoolu_a","name":"tool_search_tool_bm25","caller":{"type":"direct"},"input":{"queries":["first"]}},
+				{"type":"tool_search_tool_result","tool_use_id":"srvtoolu_a","content":{"type":"tool_search_tool_search_result","tool_references":[{"type":"tool_reference","tool_name":"alpha"}]}},
+				{"type":"server_tool_use","id":"srvtoolu_b","name":"tool_search_tool_bm25","caller":{"type":"direct"},"input":{"queries":["second"]}},
+				{"type":"tool_search_tool_result","tool_use_id":"srvtoolu_b","content":{"type":"tool_search_tool_search_result","tool_references":[{"type":"tool_reference","tool_name":"beta"}]}}
+			]`,
+			wantSearch: []ToolSearch{
+				{ToolUseID: "srvtoolu_a", ToolName: "tool_search_tool_bm25", Query: json.RawMessage(`{"queries":["first"]}`), ToolsFound: []string{"alpha"}},
+				{ToolUseID: "srvtoolu_b", ToolName: "tool_search_tool_bm25", Query: json.RawMessage(`{"queries":["second"]}`), ToolsFound: []string{"beta"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := require.New(t)
+
+			var message anthropic.Message
+			err := json.Unmarshal([]byte(`{"content":`+tt.content+`}`), &message)
+			assert.NoError(err)
+
+			searches := extractToolSearches(message)
+
+			if tt.wantNilZero {
+				assert.Empty(searches)
+				return
+			}
+
+			assert.Len(searches, len(tt.wantSearch))
+			for i, want := range tt.wantSearch {
+				got := searches[i]
+				assert.Equal(want.ToolUseID, got.ToolUseID)
+				assert.Equal(want.ToolName, got.ToolName)
+				assert.Equal(want.ToolsFound, got.ToolsFound)
+				assert.Equal(want.Error, got.Error)
+				assert.JSONEq(string(want.Query), string(got.Query))
+			}
+		})
+	}
+}
+
 func TestEvalClient_loadMCPSession_CustomEnv(t *testing.T) {
 	assert := require.New(t)
 

--- a/mcp_evals_test.go
+++ b/mcp_evals_test.go
@@ -437,6 +437,85 @@ func TestRepairToolSearchBlocks_OutOfRange(t *testing.T) {
 	assert.Equal("hi", message.Content[0].Text)
 }
 
+// countMessageCacheBreakpoints reports how many content blocks across all
+// messages carry a cache_control breakpoint, and the index of the last message
+// that carries one (-1 if none).
+func countMessageCacheBreakpoints(messages []anthropic.MessageParam) (count, lastMsgIdx int) {
+	lastMsgIdx = -1
+	for i := range messages {
+		content := messages[i].Content
+		for j := range content {
+			block := content[j]
+			var set bool
+			switch {
+			case block.OfText != nil:
+				set = block.OfText.CacheControl.Type != ""
+			case block.OfToolResult != nil:
+				set = block.OfToolResult.CacheControl.Type != ""
+			case block.OfToolUse != nil:
+				set = block.OfToolUse.CacheControl.Type != ""
+			}
+			if set {
+				count++
+				lastMsgIdx = i
+			}
+		}
+	}
+	return count, lastMsgIdx
+}
+
+func TestApplyRollingCacheBreakpoint(t *testing.T) {
+	assert := require.New(t)
+
+	cc := anthropic.NewCacheControlEphemeralParam()
+
+	// Simulate an agentic loop that grows the message history each step, applying
+	// the rolling breakpoint before each request.
+	messages := []anthropic.MessageParam{
+		anthropic.NewUserMessage(anthropic.NewTextBlock("initial prompt")),
+	}
+
+	applyRollingCacheBreakpoint(messages, cc)
+	count, lastIdx := countMessageCacheBreakpoints(messages)
+	assert.Equal(1, count, "exactly one breakpoint after step 1")
+	assert.Equal(0, lastIdx, "breakpoint on the only message")
+
+	// Step 2: append an assistant turn and a user tool-result turn.
+	messages = append(messages,
+		anthropic.NewAssistantMessage(anthropic.NewTextBlock("calling a tool")),
+		anthropic.NewUserMessage(anthropic.NewToolResultBlock("tool_1", "result data", false)),
+	)
+	applyRollingCacheBreakpoint(messages, cc)
+	count, lastIdx = countMessageCacheBreakpoints(messages)
+	assert.Equal(1, count, "still exactly one breakpoint after step 2 (previous cleared)")
+	assert.Equal(len(messages)-1, lastIdx, "breakpoint moved to the latest message")
+
+	// Step 3: grow again; the single breakpoint should follow the tail.
+	messages = append(messages,
+		anthropic.NewAssistantMessage(anthropic.NewTextBlock("calling another tool")),
+		anthropic.NewUserMessage(anthropic.NewToolResultBlock("tool_2", "more data", false)),
+	)
+	applyRollingCacheBreakpoint(messages, cc)
+	count, lastIdx = countMessageCacheBreakpoints(messages)
+	assert.Equal(1, count, "still exactly one breakpoint after step 3")
+	assert.Equal(len(messages)-1, lastIdx, "breakpoint on the final tool-result message")
+
+	// The breakpoint must land on the last block of the last message.
+	last := messages[len(messages)-1]
+	tail := last.Content[len(last.Content)-1]
+	assert.NotNil(tail.OfToolResult)
+	assert.NotEmpty(string(tail.OfToolResult.CacheControl.Type))
+}
+
+func TestApplyRollingCacheBreakpoint_Empty(t *testing.T) {
+	assert := require.New(t)
+	// Must not panic on empty input or a message with no content blocks.
+	assert.NotPanics(func() {
+		applyRollingCacheBreakpoint(nil, anthropic.NewCacheControlEphemeralParam())
+		applyRollingCacheBreakpoint([]anthropic.MessageParam{{}}, anthropic.NewCacheControlEphemeralParam())
+	})
+}
+
 func TestEvalClient_loadMCPSession_CustomEnv(t *testing.T) {
 	assert := require.New(t)
 

--- a/mcp_evals_test.go
+++ b/mcp_evals_test.go
@@ -356,6 +356,87 @@ func TestExtractToolSearches(t *testing.T) {
 	}
 }
 
+// accumulateStream replays the given stream event JSON payloads into a Message
+// the same way RunEval does, capturing the intact content_block_start payload of
+// any tool_search_tool_result block by index so it can later be repaired.
+func accumulateStream(t *testing.T, events []string) (anthropic.Message, map[int64]string) {
+	t.Helper()
+	assert := require.New(t)
+
+	var message anthropic.Message
+	raws := map[int64]string{}
+	for _, raw := range events {
+		var ev anthropic.MessageStreamEventUnion
+		assert.NoError(json.Unmarshal([]byte(raw), &ev))
+		assert.NoError(message.Accumulate(ev))
+		if start, ok := ev.AsAny().(anthropic.ContentBlockStartEvent); ok {
+			if start.ContentBlock.Type == "tool_search_tool_result" {
+				raws[start.Index] = start.ContentBlock.RawJSON()
+			}
+		}
+	}
+	return message, raws
+}
+
+// TestRepairToolSearchBlocks reproduces the anthropic-sdk-go v1.52.0 streaming
+// bug where accumulation collapses a tool_search_tool_result block into an empty
+// error variant, then verifies that restoring the captured content_block_start
+// payload makes both trace extraction and the message.ToParam history round-trip
+// work again.
+func TestRepairToolSearchBlocks(t *testing.T) {
+	assert := require.New(t)
+
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_1","name":"tool_search_tool_bm25","caller":{"type":"direct"},"input":{"queries":["add"]}}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"tool_search_tool_result","tool_use_id":"srvtoolu_1","content":{"type":"tool_search_tool_search_result","tool_references":[{"type":"tool_reference","tool_name":"add"}]}}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}`,
+		`{"type":"message_stop"}`,
+	}
+
+	message, raws := accumulateStream(t, events)
+
+	// Sanity check: streaming accumulation really does corrupt the block, so the
+	// test exercises the bug rather than a no-op. This is the exact payload the
+	// API rejects with "RequestToolSearchToolResultError.error_code: Field required".
+	before, err := json.Marshal(message.ToParam())
+	assert.NoError(err)
+	assert.Contains(string(before), "tool_search_tool_result_error")
+	assert.Len(raws, 1)
+
+	repairToolSearchBlocks(&message, raws)
+
+	// Trace extraction recovers the surfaced tool references.
+	searches := extractToolSearches(message)
+	assert.Len(searches, 1)
+	assert.Equal([]string{"add"}, searches[0].ToolsFound)
+	assert.Empty(searches[0].Error)
+
+	// The history round-trip now serializes the success variant the API accepts.
+	after, err := json.Marshal(message.ToParam())
+	assert.NoError(err)
+	assert.NotContains(string(after), "tool_search_tool_result_error")
+	assert.Contains(string(after), "tool_search_tool_search_result")
+	assert.Contains(string(after), `"tool_name":"add"`)
+}
+
+// TestRepairToolSearchBlocks_OutOfRange ensures stale or mismatched indexes are
+// ignored rather than panicking.
+func TestRepairToolSearchBlocks_OutOfRange(t *testing.T) {
+	assert := require.New(t)
+
+	var message anthropic.Message
+	assert.NoError(json.Unmarshal([]byte(`{"role":"assistant","content":[{"type":"text","text":"hi"}]}`), &message))
+
+	// Indexes outside the content slice must be skipped without panicking.
+	repairToolSearchBlocks(&message, map[int64]string{-1: "{}", 5: "{}"})
+
+	assert.Len(message.Content, 1)
+	assert.Equal("hi", message.Content[0].Text)
+}
+
 func TestEvalClient_loadMCPSession_CustomEnv(t *testing.T) {
 	assert := require.New(t)
 

--- a/mcp_evals_test.go
+++ b/mcp_evals_test.go
@@ -3,8 +3,10 @@ package evaluations
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -123,6 +125,129 @@ func TestEvalClient_loadMCPSession_ToolExecution(t *testing.T) {
 	assert.Equal("TEST_VAR", output.Name)
 	assert.Equal("test_value", output.Value)
 	assert.True(output.Set)
+}
+
+func TestEvalClient_buildTools(t *testing.T) {
+	mcpTools := []*mcp.Tool{
+		{Name: "add", Description: "Add two integers"},
+		{Name: "echo", Description: "Echo the input"},
+		{Name: "get_user", Description: "Look up a user profile"},
+	}
+
+	tests := []struct {
+		name             string
+		enableToolSearch *bool
+		enableCaching    *bool
+		mcpTools         []*mcp.Tool
+		wantSearchTool   bool
+		wantDeferLoading bool
+		wantCacheControl bool
+		wantToolCount    int // total entries returned (MCP tools + optional search tool)
+	}{
+		{
+			name:             "defaults defer tools and add search tool",
+			mcpTools:         mcpTools,
+			wantSearchTool:   true,
+			wantDeferLoading: true,
+			wantCacheControl: true,
+			wantToolCount:    len(mcpTools) + 1,
+		},
+		{
+			name:             "tool search disabled sends tools eagerly",
+			enableToolSearch: toPtr(false),
+			mcpTools:         mcpTools,
+			wantSearchTool:   false,
+			wantDeferLoading: false,
+			wantCacheControl: true,
+			wantToolCount:    len(mcpTools),
+		},
+		{
+			name:             "caching disabled omits cache control",
+			enableCaching:    toPtr(false),
+			mcpTools:         mcpTools,
+			wantSearchTool:   true,
+			wantDeferLoading: true,
+			wantCacheControl: false,
+			wantToolCount:    len(mcpTools) + 1,
+		},
+		{
+			name:             "no tools means no search tool",
+			mcpTools:         nil,
+			wantSearchTool:   false,
+			wantDeferLoading: false,
+			wantCacheControl: false,
+			wantToolCount:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := require.New(t)
+
+			client := NewEvalClient(EvalClientConfig{
+				Command:             "go",
+				Args:                []string{"run", "testdata/mcp-test-server/main.go"},
+				EnableToolSearch:    tt.enableToolSearch,
+				EnablePromptCaching: tt.enableCaching,
+			})
+
+			tools := client.buildTools(tt.mcpTools)
+			assert.Len(tools, tt.wantToolCount)
+
+			// Count the deferred MCP tools and the BM25 search tool.
+			var deferredCount int
+			var mcpCount int
+			var searchTool *anthropic.ToolUnionParam
+			for i := range tools {
+				if tools[i].OfTool != nil {
+					mcpCount++
+					if tools[i].OfTool.DeferLoading.Valid() && tools[i].OfTool.DeferLoading.Value {
+						deferredCount++
+					}
+				}
+				if tools[i].OfToolSearchToolBm25_20251119 != nil {
+					searchTool = &tools[i]
+				}
+			}
+
+			assert.Equal(len(tt.mcpTools), mcpCount, "all MCP tools should be present")
+
+			if tt.wantSearchTool {
+				assert.NotNil(searchTool, "BM25 tool-search tool should be appended")
+				// The search tool itself must never be deferred.
+				assert.False(searchTool.OfToolSearchToolBm25_20251119.DeferLoading.Valid())
+			} else {
+				assert.Nil(searchTool, "no tool-search tool should be appended")
+			}
+
+			if tt.wantDeferLoading {
+				assert.Equal(mcpCount, deferredCount, "every MCP tool should be deferred")
+			} else {
+				assert.Zero(deferredCount, "no MCP tool should be deferred")
+			}
+
+			// Cache control lands on the last tool in the array.
+			if len(tools) > 0 {
+				last := tools[len(tools)-1]
+				var cacheSet bool
+				switch {
+				case last.OfTool != nil:
+					cacheSet = last.OfTool.CacheControl.Type != ""
+				case last.OfToolSearchToolBm25_20251119 != nil:
+					cacheSet = last.OfToolSearchToolBm25_20251119.CacheControl.Type != ""
+				}
+				assert.Equal(tt.wantCacheControl, cacheSet)
+			}
+
+			// Verify the serialized wire shape matches expectations.
+			payload, err := json.Marshal(tools)
+			assert.NoError(err)
+			serialized := string(payload)
+			assert.Equal(tt.wantSearchTool, strings.Contains(serialized, "tool_search_tool_bm25"))
+			assert.Equal(tt.wantDeferLoading, strings.Contains(serialized, "\"defer_loading\":true"))
+			assert.Equal(tt.wantCacheControl, strings.Contains(serialized, "\"cache_control\""))
+		})
+	}
 }
 
 func TestEvalClient_loadMCPSession_CustomEnv(t *testing.T) {

--- a/mcp_evals_test.go
+++ b/mcp_evals_test.go
@@ -226,17 +226,38 @@ func TestEvalClient_buildTools(t *testing.T) {
 				assert.Zero(deferredCount, "no MCP tool should be deferred")
 			}
 
-			// Cache control lands on the last tool in the array.
-			if len(tools) > 0 {
+			// Exactly one cache breakpoint should exist when caching is enabled,
+			// and it must land on the last tool in the array.
+			var cacheCount int
+			for i := range tools {
+				switch {
+				case tools[i].OfTool != nil && tools[i].OfTool.CacheControl.Type != "":
+					cacheCount++
+				case tools[i].OfToolSearchToolBm25_20251119 != nil && tools[i].OfToolSearchToolBm25_20251119.CacheControl.Type != "":
+					cacheCount++
+				}
+			}
+			if tt.wantCacheControl {
+				assert.Equal(1, cacheCount, "exactly one cache breakpoint expected")
+
 				last := tools[len(tools)-1]
-				var cacheSet bool
+				var lastCacheSet bool
 				switch {
 				case last.OfTool != nil:
-					cacheSet = last.OfTool.CacheControl.Type != ""
+					lastCacheSet = last.OfTool.CacheControl.Type != ""
 				case last.OfToolSearchToolBm25_20251119 != nil:
-					cacheSet = last.OfToolSearchToolBm25_20251119.CacheControl.Type != ""
+					lastCacheSet = last.OfToolSearchToolBm25_20251119.CacheControl.Type != ""
 				}
-				assert.Equal(tt.wantCacheControl, cacheSet)
+				assert.True(lastCacheSet, "cache control should land on the last tool")
+
+				// When tool search is on, the last tool is the search tool, so the
+				// breakpoint must sit on the search tool rather than an MCP tool.
+				if tt.wantSearchTool {
+					assert.NotNil(last.OfToolSearchToolBm25_20251119, "breakpoint should be on the search tool")
+					assert.NotEmpty(string(last.OfToolSearchToolBm25_20251119.CacheControl.Type))
+				}
+			} else {
+				assert.Zero(cacheCount, "no cache breakpoint expected")
 			}
 
 			// Verify the serialized wire shape matches expectations.

--- a/testdata/mcp-test-evals.yaml
+++ b/testdata/mcp-test-evals.yaml
@@ -8,6 +8,10 @@ max_tokens: 4096
 # enable_prompt_caching: true   # Default: true. Set to false to disable caching.
 # cache_ttl: "5m"                # Default: "5m" (free). Options: "5m" or "1h" (premium).
 
+# Tool search defers MCP tool schemas and adds a BM25 tool-search tool so the
+# model loads only the tools relevant to each prompt.
+# enable_tool_search: true       # Default: true. Set to false to send all tools eagerly.
+
 mcp_server:
   command: go
   args:


### PR DESCRIPTION
Adds opt-out tool search so the model loads only the MCP tool schemas relevant to each prompt, plus the fixes needed to make the agentic loop correct and cost-efficient when it's on. Production agents already run with tool search, so eagerly sending every schema was measuring a different system than we ship.

Changes:
* Tool search (enable_tool_search, default true): marks MCP tools defer_loading and appends a BM25 tool_search_tool_bm25 tool. Set false to restore eager loading. Tool construction extracted into a testable buildTools method.
* Trace visibility: server-side searches were invisible. Adds ToolSearch records (query, tools found, error) per step, an aggregate ToolSearchCount, and report rendering.
* Streaming SDK fix: anthropic-sdk-go v1.52.0 corrupts tool_search_tool_result blocks during accumulation, causing a 400 on the history round-trip. Captures the intact content_block_start payload and restores the block.
* pause_turn: server-side tools make pause_turn reachable; the loop now resumes instead of ending the eval early.

## Breaking change

`enable_tool_search` defaults to **true**, so existing configs now defer MCP tool schemas behind the search tool. This can shift eval results (the model discovers tools via search rather than having them all present). Set `enable_tool_search: false` to restore the previous eager behaviour.