### PR TITLE
fix: merge tool-search records split across agentic steps

### DIFF
--- a/mcp_evals.go
+++ b/mcp_evals.go
@@ -283,6 +283,58 @@ func extractToolSearches(message anthropic.Message) []ToolSearch {
 	return searches
 }
 
+// reconcileToolSearches merges tool-search records that are split across agentic
+// steps. A search emits its server_tool_use (which carries the query) and its
+// tool_search_tool_result (which carries the surfaced tools) in one response, but
+// the API can defer the result into the next step's response. That leaves two
+// half-records sharing a tool_use_id: the initiating step has the query with no
+// results, and the following step has the results with no query.
+//
+// The split records are merged by ID into the step that initiated the search
+// (the first occurrence, which holds the query) and the trailing duplicate is
+// dropped, so each search is recorded once and ToolSearchCount is not inflated.
+func reconcileToolSearches(steps []AgenticStep) {
+	// Pass 1: accumulate the most complete record for each tool-use ID.
+	merged := make(map[string]*ToolSearch)
+	for i := range steps {
+		for _, s := range steps[i].ToolSearches {
+			m, ok := merged[s.ToolUseID]
+			if !ok {
+				cp := s
+				merged[s.ToolUseID] = &cp
+				continue
+			}
+			if m.ToolName == "" {
+				m.ToolName = s.ToolName
+			}
+			if len(m.Query) == 0 {
+				m.Query = s.Query
+			}
+			if len(m.ToolsFound) == 0 {
+				m.ToolsFound = s.ToolsFound
+			}
+			if m.Error == "" {
+				m.Error = s.Error
+			}
+		}
+	}
+
+	// Pass 2: keep the first occurrence of each ID (now fully populated) and drop
+	// any later half-records for the same search.
+	seen := make(map[string]bool)
+	for i := range steps {
+		out := steps[i].ToolSearches[:0]
+		for _, s := range steps[i].ToolSearches {
+			if seen[s.ToolUseID] {
+				continue
+			}
+			seen[s.ToolUseID] = true
+			out = append(out, *merged[s.ToolUseID])
+		}
+		steps[i].ToolSearches = out
+	}
+}
+
 // repairToolSearchBlocks restores tool_search_tool_result content blocks that
 // anthropic-sdk-go v1.52.0 corrupts during streaming accumulation.
 //
@@ -477,6 +529,10 @@ func (ec *EvalClient) RunEval(ctx context.Context, eval Eval) (*EvalRunResult, e
 		// Add tool results to message history
 		messages = append(messages, anthropic.NewUserMessage(toolResults...))
 	}
+
+	// Merge tool-search records split across steps before counting, so a search
+	// whose result the API deferred into the next step is recorded once.
+	reconcileToolSearches(trace.Steps)
 
 	// Calculate trace metrics
 	trace.StepCount = len(trace.Steps)

--- a/mcp_evals_test.go
+++ b/mcp_evals_test.go
@@ -437,6 +437,55 @@ func TestRepairToolSearchBlocks_OutOfRange(t *testing.T) {
 	assert.Equal("hi", message.Content[0].Text)
 }
 
+func TestReconcileToolSearches(t *testing.T) {
+	assert := require.New(t)
+
+	// Reproduces the observed split: the search initiated in step 1 (query, no
+	// results) has its result deferred into step 2 (results, no query), sharing a
+	// tool_use_id. A second, self-contained search lives entirely in step 1.
+	steps := []AgenticStep{
+		{
+			StepNumber: 1,
+			ToolSearches: []ToolSearch{
+				{ToolUseID: "srv_a", ToolName: "tool_search_tool_bm25", Query: json.RawMessage(`{"query":"complete"}`), ToolsFound: []string{"alpha"}},
+				{ToolUseID: "srv_b", ToolName: "tool_search_tool_bm25", Query: json.RawMessage(`{"query":"deferred"}`)},
+			},
+		},
+		{
+			StepNumber: 2,
+			ToolSearches: []ToolSearch{
+				{ToolUseID: "srv_b", ToolsFound: []string{"beta", "gamma"}},
+			},
+		},
+	}
+
+	reconcileToolSearches(steps)
+
+	// The self-contained search is untouched; the deferred search is merged into
+	// step 1 and removed from step 2.
+	assert.Len(steps[0].ToolSearches, 2)
+	assert.Empty(steps[1].ToolSearches, "trailing half-record should be dropped")
+
+	// Find the merged srv_b record in step 1.
+	var merged *ToolSearch
+	for i := range steps[0].ToolSearches {
+		if steps[0].ToolSearches[i].ToolUseID == "srv_b" {
+			merged = &steps[0].ToolSearches[i]
+		}
+	}
+	assert.NotNil(merged, "deferred search should be attributed to its initiating step")
+	assert.Equal("tool_search_tool_bm25", merged.ToolName, "name from the initiating half")
+	assert.JSONEq(`{"query":"deferred"}`, string(merged.Query), "query from the initiating half")
+	assert.Equal([]string{"beta", "gamma"}, merged.ToolsFound, "results from the trailing half")
+
+	// Counting now yields the distinct number of searches, not the inflated total.
+	total := 0
+	for i := range steps {
+		total += len(steps[i].ToolSearches)
+	}
+	assert.Equal(2, total, "two distinct searches, not three half-records")
+}
+
 // countMessageCacheBreakpoints reports how many content blocks across all
 // messages carry a cache_control breakpoint, and the index of the last message
 // that carries one (-1 if none).


### PR DESCRIPTION
A server-side search emits its server_tool_use (carrying the query) and its tool_search_tool_result (carrying the surfaced tools) in one response, but the API can defer the result into the next step's response. That left two half-records sharing a tool_use_id -- the initiating step with a query and no results, the next step with results and no query -- so the search was traced twice and ToolSearchCount was inflated (e.g. 6 reported for 5 actual searches).

Add reconcileToolSearches to merge half-records by tool_use_id into the step that initiated the search and drop the trailing duplicate, so each search is recorded once with both its query and results.
